### PR TITLE
Fix scoring display bug showing 0/0 instead of 0/10

### DIFF
--- a/src/pages/course/[id].tsx
+++ b/src/pages/course/[id].tsx
@@ -370,7 +370,7 @@ export default function CoursePage() {
               </div>
               <div className="flex items-center gap-2">
                 <CheckCircle className="h-4 w-4" />
-                {correctAnswers}/{answeredQuestions.size} Correct
+                {correctAnswers}/{questions.length} Correct
               </div>
               {duration > 0 && (
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
Fix scoring display showing "0/0 Correct" instead of "0/10 Correct" in the course viewer

## Changes
- Updated course stats display in `src/pages/course/[id].tsx:373` to use `questions.length` instead of `answeredQuestions.size` for total questions count
- This ensures the display shows the actual total number of questions available, not just the number answered so far

## Test plan
- [ ] Load a course with multiple questions
- [ ] Verify the scoring display shows "0/X Correct" where X is the total number of questions
- [ ] Answer questions and verify the display updates correctly (e.g., "1/10 Correct", "2/10 Correct")

🤖 Generated with [Claude Code](https://claude.ai/code)