### PR TITLE
Add MIT License to CourseForge AI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 CourseForge AI Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Add MIT License to the CourseForge AI project to establish clear legal terms for open source contributions and usage.

## Why MIT License?
After evaluating MIT vs Apache 2.0, MIT License was chosen for CourseForge AI because:

### ✅ **Simplicity & Clarity**
- Clear, well-understood terms for contributors
- Minimal legal complexity
- Easy for developers to understand and comply with

### 🎓 **Educational Mission Alignment**
- Supports the democratizing education mission
- Encourages broad adoption in educational contexts
- Aligns with open source educational tools

### 🚀 **Commercial Flexibility**
- Allows future monetization without license conflicts
- Enables commercial use while maintaining open source core
- Compatible with business model evolution

### 🌍 **Ecosystem Compatibility**
- Most open source projects use MIT
- Broad compatibility with other licenses
- Reduces friction for contributors and users

### 👥 **Developer Friendly**
- Encourages contributions from developers
- Minimal barriers to entry
- Clear attribution requirements

## License Details
- **Copyright**: "CourseForge AI Contributors" (acknowledging collaborative nature)
- **Year**: 2025
- **Standard MIT terms**: Permissive use with attribution requirement

## Legal Protection
The MIT License provides:
- Clear usage rights for end users
- Attribution requirements for derivative works
- Limitation of liability for project maintainers
- Warranty disclaimers for software reliability

## Files Added
- `LICENSE` - Standard MIT License text with CourseForge AI branding

## Next Steps
After merging this PR:
- [ ] Update README.md to reference the license
- [ ] Add license badge to project documentation
- [ ] Consider adding license headers to source files (optional)

🤖 Generated with [Claude Code](https://claude.ai/code)