### PR TITLE
fix: Remove duplicate timestamps from video player

### DIFF
--- a/src/components/InteractiveVideoPlayer.tsx
+++ b/src/components/InteractiveVideoPlayer.tsx
@@ -102,13 +102,7 @@ const InteractiveVideoPlayer: React.FC<InteractiveVideoPlayerProps> = ({
         
         {/* Progress Bar */}
         {isVideoReady && duration > 0 && (
-          <div className="space-y-3 px-2">
-            <div className="flex justify-between text-sm text-muted-foreground">
-              <span>{formatTime(currentTime)}</span>
-              <span>{formatTime(duration)}</span>
-            </div>
-            
-            {/* Interactive Progress Bar */}
+          <div className="px-2">
             <VideoProgressBar
               currentTime={currentTime}
               duration={duration}


### PR DESCRIPTION
## Summary
- Fixed duplicate timestamp displays in video player UI
- Removed redundant current time/duration above progress bar
- Cleaner, more intuitive video playback controls

## Problem
The video player was showing duplicate timestamps in two places:
1. **Above progress bar**: `InteractiveVideoPlayer` component displayed current time and duration
2. **Within progress bar**: `VideoProgressBar` component already shows the same timestamps

This created confusing and redundant UI elements that detracted from the user experience.

## Solution
- **Removed** duplicate timestamp display from `InteractiveVideoPlayer` component
- **Kept** integrated timestamps within `VideoProgressBar` (proper location)
- **Maintained** course duration in header stats (appropriate context)

## Changes Made
- **src/components/InteractiveVideoPlayer.tsx**: Removed redundant timestamp div above VideoProgressBar
- Simplified container structure from `space-y-3` to clean single progress bar

## UI/UX Improvements
- **Eliminates confusion** from duplicate time displays
- **Cleaner visual hierarchy** with single timestamp source
- **Better user focus** on video content rather than redundant controls
- **Consistent with preview page** which already uses clean single progress bar

## Test Plan
- [x] Video player loads correctly
- [x] Progress bar shows timestamps properly
- [x] No duplicate time displays
- [x] Question markers still visible on progress bar
- [x] Seek functionality works as expected
- [x] Course stats header still shows total duration

🤖 Generated with [Claude Code](https://claude.ai/code)