### PR TITLE
fix: Comment out course_rating_stats queries to resolve database error

### DIFF
--- a/src/pages/api/courses.ts
+++ b/src/pages/api/courses.ts
@@ -18,12 +18,13 @@ export default async function handler(
 
   try {
     // Refresh the materialized view to ensure rating stats are up-to-date
-    const { error: refreshError } = await supabase.rpc('refresh_course_rating_stats');
-    if (refreshError) {
-      console.error('Error refreshing course_rating_stats:', refreshError);
-      // Decide if this should be a hard error or just a warning
-      // For now, let's log it and continue, as courses can still be fetched
-    }
+    // COMMENTED OUT: course_rating_stats table does not exist
+    // const { error: refreshError } = await supabase.rpc('refresh_course_rating_stats');
+    // if (refreshError) {
+    //   console.error('Error refreshing course_rating_stats:', refreshError);
+    //   // Decide if this should be a hard error or just a warning
+    //   // For now, let's log it and continue, as courses can still be fetched
+    // }
 
     // Get basic course data first (reliable baseline)
     let query = supabase
@@ -67,32 +68,33 @@ export default async function handler(
         let totalRatings = 0;
         let questionCount = 0;
 
-        try {
-          // Try to get rating stats for this course
-          const { data: ratingStats, error: ratingError } = await supabase
-            .from('course_rating_stats')
-            .select('average_rating, total_ratings')
-            .eq('course_id', course.id)
-            .maybeSingle(); // Use maybeSingle to handle no results gracefully
+        // COMMENTED OUT: course_rating_stats table does not exist
+        // try {
+        //   // Try to get rating stats for this course
+        //   const { data: ratingStats, error: ratingError } = await supabase
+        //     .from('course_rating_stats')
+        //     .select('average_rating, total_ratings')
+        //     .eq('course_id', course.id)
+        //     .maybeSingle(); // Use maybeSingle to handle no results gracefully
 
-          if (!ratingError && ratingStats) {
-            averageRating = Number(ratingStats.average_rating) || 0;
-            totalRatings = Number(ratingStats.total_ratings) || 0;
+        //   if (!ratingError && ratingStats) {
+        //     averageRating = Number(ratingStats.average_rating) || 0;
+        //     totalRatings = Number(ratingStats.total_ratings) || 0;
             
-            // Debug: Log rating data for courses that have ratings
-            if (totalRatings > 0) {
-              console.log(`⭐ Course "${course.title}" has ratings:`, {
-                averageRating,
-                totalRatings,
-                courseId: course.id
-              });
-            }
-          } else if (ratingError) {
-            console.warn(`❌ Rating error for course ${course.id}:`, ratingError);
-          }
-        } catch (ratingError) {
-          console.warn(`❌ Rating fetch error for course ${course.id}:`, ratingError);
-        }
+        //     // Debug: Log rating data for courses that have ratings
+        //     if (totalRatings > 0) {
+        //       console.log(`⭐ Course "${course.title}" has ratings:`, {
+        //         averageRating,
+        //         totalRatings,
+        //         courseId: course.id
+        //       });
+        //     }
+        //   } else if (ratingError) {
+        //     console.warn(`❌ Rating error for course ${course.id}:`, ratingError);
+        //   }
+        // } catch (ratingError) {
+        //   console.warn(`❌ Rating fetch error for course ${course.id}:`, ratingError);
+        // }
 
         try {
           // Get question count for this course


### PR DESCRIPTION
- Fixed relation "public.course_rating_stats" does not exist error
- Commented out refresh_course_rating_stats RPC call
- Commented out course_rating_stats table queries
- API now returns default rating values (0) instead of crashing
- Question counts and other course data still work normally