### PR TITLE
fix: Update onboarding APIs to use existing profiles table schema

### DIFF
--- a/src/pages/api/user/check-onboarding.ts
+++ b/src/pages/api/user/check-onboarding.ts
@@ -19,9 +19,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const { data, error } = await supabase
-      .from('user_profiles')
-      .select('onboarding_completed')
-      .eq('user_id', user_id)
+      .from('profiles')
+      .select('notification_preferences')
+      .eq('id', user_id)
       .single();
 
     if (error) {
@@ -35,8 +35,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       throw error;
     }
 
+    // Check onboarding status from notification_preferences JSON field
+    const notificationPrefs = data?.notification_preferences || {};
+    const onboardingCompleted = notificationPrefs.onboarding_completed || false;
+
     return res.status(200).json({ 
-      onboarding_completed: data?.onboarding_completed || false,
+      onboarding_completed: onboardingCompleted,
       profile_exists: true 
     });
   } catch (error) {


### PR DESCRIPTION
- Fixed check-onboarding API to query profiles table instead of non-existent user_profiles
- Updated update-onboarding API to use profiles.notification_preferences for onboarding status
- Store onboarding_completed flag in notification_preferences JSON field
- Use profiles.id instead of user_profiles.user_id to match actual schema
- Maintain backward compatibility with existing notification preferences structure
- Resolve "relation public.user_profiles does not exist" database errors

🤖 Generated with [Claude Code](https://claude.ai/code)